### PR TITLE
Remove hardcoded wedding vendor routes from App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,19 +145,7 @@ function App() {
             <Route path="/:vendorSlug/booking" element={<WeddingModule />} />
             <Route path="/:vendorSlug/booking/:serviceId" element={<WeddingModule />} />
 
-            {/* Individual wedding vendor pages */}
-            <Route path="/elegant-events" element={<WeddingModule />} />
-            <Route path="/elegant-events/portfolio" element={<WeddingModule />} />
-            <Route path="/elegant-events/dashboard" element={<WeddingModule />} />
-            <Route path="/bloom-bridal" element={<WeddingModule />} />
-            <Route path="/bloom-bridal/portfolio" element={<WeddingModule />} />
-            <Route path="/bloom-bridal/dashboard" element={<WeddingModule />} />
-            <Route path="/enchanted-venues" element={<WeddingModule />} />
-            <Route path="/enchanted-venues/portfolio" element={<WeddingModule />} />
-            <Route path="/enchanted-venues/dashboard" element={<WeddingModule />} />
-            <Route path="/sweet-celebrations" element={<WeddingModule />} />
-            <Route path="/sweet-celebrations/portfolio" element={<WeddingModule />} />
-            <Route path="/sweet-celebrations/dashboard" element={<WeddingModule />} />
+            
 
             {/* Hotel-specific Routes (more specific routes first) */}
             <Route path="/:hotelSlug/rooms/:roomId" element={<HotelModule />} />


### PR DESCRIPTION
Removed hardcoded individual wedding vendor routes from the routing configuration.

The following routes were removed:
- /elegant-events and its portfolio/dashboard subroutes
- /bloom-bridal and its portfolio/dashboard subroutes  
- /enchanted-venues and its portfolio/dashboard subroutes
- /sweet-celebrations and its portfolio/dashboard subroutes

These routes are now handled by the existing dynamic vendor routing pattern using /:vendorSlug.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/2e6facf3799e4e48b73ee6fd721e5752/vibe-forge)

👀 [Preview Link](https://2e6facf3799e4e48b73ee6fd721e5752-vibe-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e6facf3799e4e48b73ee6fd721e5752</projectId>-->
<!--<branchName>vibe-forge</branchName>-->