### PR TITLE
Fix confirm password validation in registration forms

### DIFF
--- a/src/components/auth/AuthModal.js
+++ b/src/components/auth/AuthModal.js
@@ -403,7 +403,9 @@ const AuthModal = ({ isOpen, onClose, onSuccess, defaultTab = 'login' }) => {
         newErrors.phone = 'Phone number is required';
       }
 
-      if (formData.password !== formData.confirmPassword) {
+      if (!formData.confirmPassword.trim()) {
+        newErrors.confirmPassword = 'Please enter confirm password';
+      } else if (formData.password !== formData.confirmPassword) {
         newErrors.confirmPassword = "Passwords don't match";
       }
 

--- a/src/components/auth/RegisterPage.js
+++ b/src/components/auth/RegisterPage.js
@@ -384,6 +384,12 @@ const RegisterPage = () => {
       dispatch(clearError());
     }
 
+    // Validate confirm password is provided
+    if (!formData.confirmPassword.trim()) {
+      setValidationError('Please enter confirm password');
+      return;
+    }
+
     // Validate passwords match
     if (formData.password !== formData.confirmPassword) {
       setValidationError("Passwords don't match!");

--- a/src/components/auth/RegisterPage.js
+++ b/src/components/auth/RegisterPage.js
@@ -401,6 +401,7 @@ const RegisterPage = () => {
       name: `${formData.firstName} ${formData.lastName}`,
       email: formData.email,
       password: formData.password,
+      confirmPassword: formData.confirmPassword,
       phone: formData.phone,
       role: formData.role,
       businessName: formData.businessName,


### PR DESCRIPTION
## Purpose
User reported a registration bug where the system was throwing "enter confirm password" error even when the confirm password field was filled. The user needed the registration form to properly validate the confirm password field and accept valid registration requests with matching passwords.

## Code changes
- **AuthModal.js**: Added validation to check if confirm password field is empty before checking password match
- **RegisterPage.js**: Added confirm password empty field validation and included confirmPassword in the registration request payload
- Both components now properly validate that confirm password is provided before comparing passwords
- Fixed the registration request to include the confirmPassword field as required by the API

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 92`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f46a815d540a490286b8641b5d3b4cff/neon-zone)

👀 [Preview Link](https://f46a815d540a490286b8641b5d3b4cff-neon-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f46a815d540a490286b8641b5d3b4cff</projectId>-->
<!--<branchName>neon-zone</branchName>-->